### PR TITLE
Speed Improvement in "power_curve_density_correction"

### DIFF
--- a/windpowerlib/power_output.py
+++ b/windpowerlib/power_output.py
@@ -172,14 +172,11 @@ def power_curve(
 
 
 def power_curve_density_correction(
-    wind_speed, power_curve_wind_speeds, power_curve_values, density
-):
+    wind_speed, power_curve_wind_speeds, power_curve_values, density):
     r"""
     Calculates the turbine power output using a density corrected power curve.
-
     This function is carried out when the parameter `density_correction` of an
     instance of the :class:`~.modelchain.ModelChain` class is True.
-
     Parameters
     ----------
     wind_speed : :pandas:`pandas.Series<series>` or numpy.array
@@ -192,21 +189,17 @@ def power_curve_density_correction(
         `power_curve_wind_speeds`.
     density : :pandas:`pandas.Series<series>` or numpy.array
         Density of air at hub height in kg/m³.
-
     Returns
     -------
     :pandas:`pandas.Series<series>` or numpy.array
         Electrical power output of the wind turbine in W.
         Data type depends on type of `wind_speed`.
-
     Notes
     -----
     The following equation is used for the site specific power curve wind
     speeds [1]_ [2]_ [3]_:
-
     .. math:: v_{site}=v_{std}\cdot\left(\frac{\rho_0}
                        {\rho_{site}}\right)^{p(v)}
-
     with:
         .. math:: p=\begin{cases}
                       \frac{1}{3} & v_{std} \leq 7.5\text{ m/s}\\
@@ -214,19 +207,15 @@ def power_curve_density_correction(
                       \text{ m/s}<v_{std}<12.5\text{ m/s}\\
                       \frac{2}{3} & \geq 12.5 \text{ m/s}
                     \end{cases},
-
         v: wind speed [m/s], :math:`\rho`: density [kg/m³]
-
     :math:`v_{std}` is the standard wind speed in the power curve
     (:math:`v_{std}`, :math:`P_{std}`),
     :math:`v_{site}` is the density corrected wind speed for the power curve
     (:math:`v_{site}`, :math:`P_{std}`),
     :math:`\rho_0` is the ambient density (1.225 kg/m³)
     and :math:`\rho_{site}` the density at site conditions (and hub height).
-
     It is assumed that the power output for wind speeds above the maximum
     and below the minimum wind speed given in the power curve is zero.
-
     References
     ----------
     .. [1] Svenningsen, L.: "Power Curve Air Density Correction And Other
@@ -238,7 +227,6 @@ def power_curve_density_correction(
             Variable Scale Simulation Model for Windpower based on the
             Georeferenced Installation Register of Germany". Master's Thesis
             at Reiner Lemoine Institute, 2014, p. 13
-
     """
     if density is None:
         raise TypeError(
@@ -246,6 +234,19 @@ def power_curve_density_correction(
             + "density corrected power curve density at hub "
             + "height is needed."
         )
+
+    #NOTE : CHANGES ARE MADE HERE FOR SPEED IMPROVEMENT
+    # create a flag for pandas Series type
+    Panda_series = False
+    
+    if isinstance(wind_speed, pd.Series):
+        #save the indexes for later conversion to pd.Series
+        indexes = wind_speed.index
+        # change the wind speed Series to numpy array 
+        wind_speed = wind_speed.values
+        # Set the panda flag True 
+        Panda_series = True
+
     power_output = [
         (
             np.interp(
@@ -266,10 +267,10 @@ def power_curve_density_correction(
     ]
 
     # Power_output as pd.Series if wind_speed is pd.Series (else: np.array)
-    if isinstance(wind_speed, pd.Series):
+    if Panda_series: #use the flag to check
         power_output = pd.Series(
             data=power_output,
-            index=wind_speed.index,
+            index=indexes, # Use previously saved indexes
             name="feedin_power_plant",
         )
     else:


### PR DESCRIPTION
Convert Pandas Series to Numpy Array for faster numpy interpolation (np.interp) on larger dataset.

Fixes # .
Slow performance on Large datasets in Pandas DataFrame format.

Changes proposed in this pull request:
- converts the pd.Series to np.array before using np.interp (A speed up can be obtained upto 5 - 6x while using pandas DataFrame as input data for modelchain)
